### PR TITLE
Force dynamic rendering for authenticated pages

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -5,6 +5,8 @@ import { prisma } from "@/lib/prisma";
 import { createNewBatch } from "./actions";
 import { SignOutButton } from "./SignOutButton";
 
+export const dynamic = "force-dynamic";
+
 export default async function AppPage() {
   const session = await getServerAuthSession();
   const userId = session?.user?.id;

--- a/app/wizard/page.tsx
+++ b/app/wizard/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { getServerAuthSession } from "@/lib/auth";
 
+export const dynamic = "force-dynamic";
+
 export default async function WizardPage() {
   const session = await getServerAuthSession();
 


### PR DESCRIPTION
### Motivation

- Prevent Next.js from pre-rendering pages that depend on runtime authentication state so session checks run at request time.
- Avoid build-time evaluation of `getServerAuthSession` / NextAuth logic which can cause deployment/runtime errors on Vercel.

### Description

- Mark the authenticated dashboard page as dynamic by adding `export const dynamic = "force-dynamic"` in `app/app/page.tsx`.
- Mark the wizard entry page as dynamic by adding `export const dynamic = "force-dynamic"` in `app/wizard/page.tsx`.
- This is a minimal change to ensure server-side session code executes per-request rather than during build.

### Testing

- A `next build` was executed earlier and the project compiled successfully during investigation. 
- No automated tests were run specifically after the dynamic flags were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab5af1d3883318b7e46cf9a89080a)