### PR TITLE
Fix Responses API input typing in assistant route

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -309,20 +309,10 @@ When details are missing:
 Return ONLY JSON that matches the schema.
 `.trim();
 
-    const input = [
-      {
-        role: "system",
-        content: [{ type: "input_text", text: system }]
-      },
-      {
-        role: "user",
-        content: [{ type: "input_text", text: JSON.stringify({ message, context }) }]
-      }
-    ];
-
     const resp = await client.responses.create({
       model: getModel(),
-      input,
+      instructions: system,
+      input: JSON.stringify({ message, context }),
       text: {
         format: {
           type: "json_schema",


### PR DESCRIPTION
### Motivation
- The Vercel production build failed due to a TypeScript type error when calling `client.responses.create` with an `input` array. 
- The OpenAI Responses SDK expects either `instructions` plus a string `input` payload or different typed shapes, so the previous typed array conflicted with the SDK typings. 
- The goal is to adjust the request shape to satisfy the SDK types and avoid compile errors during deployment.

### Description
- Replaced the previously constructed `input` array with `instructions: system` and `input: JSON.stringify({ message, context })` in the `client.responses.create` call. 
- Removed the local `input` variable and simplified the Responses API invocation to match the SDK's expected types. 
- Changes are localized to `app/api/assistant/route.ts` to fix typing issues while preserving the JSON schema output formatting.

### Testing
- The prior automated Vercel build failed with a TypeScript error related to `responses.create` typing. 
- No automated tests or builds were executed for this change after the update. 
- Recommend running `npm run build` and TypeScript checks to verify the fix in CI before deploying.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab72b0e5c8331947f4a2f3ae1fb4f)