### PR TITLE
Fix assistant response parsing type errors

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -94,16 +94,18 @@ const ACTION_SCHEMA = {
   }
 };
 
-function extractJsonText(resp: {
-  output_text?: string;
-  output?: Array<{ content?: Array<{ type?: string; text?: string }> }>;
-}) {
-  if (resp && typeof resp.output_text === "string" && resp.output_text.trim()) {
-    return resp.output_text.trim();
+function extractJsonText(resp: unknown) {
+  if (!resp || typeof resp !== "object") return "";
+  const maybeText = (resp as { output_text?: unknown }).output_text;
+  if (typeof maybeText === "string" && maybeText.trim()) {
+    return maybeText.trim();
   }
-  const out = Array.isArray(resp?.output) ? resp.output : [];
-  for (const item of out) {
-    const content = Array.isArray(item?.content) ? item.content : [];
+  const out = (resp as { output?: unknown }).output;
+  const outputItems = Array.isArray(out) ? out : [];
+  for (const item of outputItems) {
+    const content = Array.isArray((item as { content?: unknown })?.content)
+      ? (item as { content?: Array<{ type?: unknown; text?: unknown }> }).content
+      : [];
     for (const chunk of content) {
       if (
         chunk?.type === "output_text" &&


### PR DESCRIPTION
### Motivation
- A Next.js/TypeScript build failed due to a type mismatch when parsing the OpenAI `responses.create` return value in `app/api/assistant/route.ts`.
- The previous `extractJsonText` signature assumed a strict shape which didn't cover variant response item types like tool calls, causing compile-time errors.
- Make the assistant response parsing robust to different response shapes emitted by the OpenAI client so builds no longer fail on unexpected types.

### Description
- Change `extractJsonText` to accept `unknown` and perform runtime type guards instead of relying on a narrow TypeScript shape. 
- Safely read `output_text` and iterate `output` items only when they are arrays, and defensively handle `content` entries with loose `type`/`text` checks. 
- Preserve previous behavior by returning the trimmed output text when found and returning an empty string when no JSON text is present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab7d7540c83318de70dc55fea058a)