### PR TITLE
Fix assistant output parsing type safety

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -104,7 +104,8 @@ function extractJsonText(resp: unknown) {
   const outputItems = Array.isArray(out) ? out : [];
   for (const item of outputItems) {
     const content = Array.isArray((item as { content?: unknown })?.content)
-      ? (item as { content?: Array<{ type?: unknown; text?: unknown }> }).content
+      ? (item as { content?: Array<{ type?: unknown; text?: unknown }> })
+          .content ?? []
       : [];
     for (const chunk of content) {
       if (


### PR DESCRIPTION
### Motivation
- The production build was failing with a TypeScript error where `content` could be `undefined` and was being iterated with `for ... of`.
- The root cause is that model response items may omit a `content` field, allowing `undefined` to reach the extraction loop.

### Description
- Update `extractJsonText` to coerce `item.content` to a concrete array using `?.content ?? []` before iterating.
- Narrow the cast to `Array<{ type?: unknown; text?: unknown }>` so the TypeScript checker can validate the iteration.
- This change prevents `for (const chunk of content)` from iterating over `undefined` and makes the output extraction resilient to missing fields.

### Testing
- No automated tests or builds were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab8aea7b08331b474d68c224016d8)